### PR TITLE
make the title of internship attractive

### DIFF
--- a/frontend/src/assets/Components/Internships/Internships.css
+++ b/frontend/src/assets/Components/Internships/Internships.css
@@ -102,3 +102,13 @@ body {
 .intern-internship-search-bar button:hover {
   background-color: #a5b4fc;
 }
+
+
+.intern-internship-title {
+  font-size: 3.2rem;        
+  font-weight: 700;         
+  color: #6366F1;           
+  text-align: center;
+  margin-bottom: 40px;
+  font-family: 'Poppins', sans-serif; 
+}


### PR DESCRIPTION
•Made the "Explore Internships" title a bit bigger so it stands out more clearly on the page. #174 
•Gave the title a nice indigo color (#6366F1) to make it look cleaner and more modern.
•Used the Poppins font to keep the style consistent and easy to read